### PR TITLE
Update removeAll function, now it also can delete selected option

### DIFF
--- a/jquery.sumoselect.js
+++ b/jquery.sumoselect.js
@@ -738,12 +738,15 @@
                 },
 
                 // removes all but the selected one
-                removeAll: function () {
+                // if force argument is provided, then will be deleted selected value too
+                removeAll: function (force = false) {
                     var O = this;
                     var options = O.E.find('option');
 
+                    if (typeof force !== 'boolean') throw 'force must be a boolean value'
+
                     for (var x = (options.length - 1); x >= 0; x--) {
-                        if (options[x].selected !== true) {
+                        if (force || options[x].selected !== true) {
                             O.remove(x);
                         }
                     }


### PR DESCRIPTION
In the case with Stuart bridge I faced the problem, when I have select `Country`, I must make options in the second select `City` according to selected option in `Country`, but the problem is what in default behaviour, `removeAll()` will not delete selected option, I have to do it manually – remove whole select from DOM and create it one more time..., so I a little bit monkey-patched function.